### PR TITLE
Convert to an embedded webextension

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "css",
     "html"
   ],
+  "hasEmbeddedWebExtension": true,
   "devDependencies": {
     "eslint": "^3.17.1",
     "jpm": "^1.3.0"

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,0 +1,5 @@
+{
+    "manifest_version": 2,
+    "version": "1.0.0",
+    "name": "onboard-v1"
+}


### PR DESCRIPTION
This converts the add-on to an embedded webextension which will hopefully allow us to get around the current AMO and installation problems.